### PR TITLE
Drop bld.bat

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,2 +1,0 @@
-"%PYTHON%" setup.py install
-if errorlevel 1 exit 1


### PR DESCRIPTION
It use to be the case that `bld.bat` was needed as `script` was not respected by `conda-build` on Windows. However, `conda-build` has since been fixed and `bld.bat` is respected. So here we drop the `bld.bat` file so that `script` can be leveraged on all platforms.